### PR TITLE
Pass Railway environment variables to Docker runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,15 +88,25 @@ RUN apk update && apk upgrade && \
     && mkdir -p /app /tmp \
     && chown -R astro:astro /app /tmp
 
-# Set secure runtime environment
+# Railway environment variables (passed as build args)
 ARG APP_PORT
-ENV NODE_ENV=production \
-    HOST=0.0.0.0 \
-    PORT=${APP_PORT} \
-    ASTRO_TELEMETRY_DISABLED=1 \
-    NODE_NO_WARNINGS=1 \
-    NODE_OPTIONS="--max-old-space-size=512 --max-semi-space-size=64" \
-    PATH=/app/node_modules/.bin:$PATH
+ARG URL
+ARG RESEND_API_KEY
+ARG APP_ENV
+
+# Convert ARGs to ENV for runtime availability
+ENV PORT=${APP_PORT}
+ENV URL=${URL}
+ENV RESEND_API_KEY=${RESEND_API_KEY}
+ENV APP_ENV=${APP_ENV}
+
+# Set secure runtime environment
+ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV ASTRO_TELEMETRY_DISABLED=1
+ENV NODE_NO_WARNINGS=1
+ENV NODE_OPTIONS="--max-old-space-size=512 --max-semi-space-size=64"
+ENV PATH=/app/node_modules/.bin:$PATH
 
 # Railway.app deployment optimizations
 


### PR DESCRIPTION
## Summary
Fix for Docker environment variable handling to properly pass Railway environment variables to the Docker runtime container.

## Changes

### Environment Variable Handling
- **Added build arguments**: Added `ARG` declarations for `URL`, `RESEND_API_KEY`, and `APP_ENV` to receive values during Docker build
- **ARG to ENV conversion**: Added explicit `ENV` statements to convert build arguments to runtime environment variables, ensuring they're available when the container runs
- **Separated concerns**: Split the large multi-line `ENV` statement into individual declarations for better readability and maintainability

### Technical Details
- **Fixed Railway integration**: Railway environment variables are now properly passed through the Docker build process using build arguments and converted to runtime environment variables
- **Maintained existing config**: Preserved all existing environment variables (`NODE_ENV`, `HOST`, `ASTRO_TELEMETRY_DISABLED`, etc.) with same values
- **Improved structure**: Better organization of environment variable declarations with clear separation between Railway-specific and general runtime variables

This fix ensures that essential configuration like the site URL and email API key are properly available to the Astro application at runtime when deployed on Railway.

---
🤖 Generated with gprc made by Walid + Claude