### PR TITLE
Fix Docker build by passing URL and analytics environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 ARG NODE_VERSION=22
 ARG PNPM_VERSION=10.12.4
 ARG APP_PORT=4321
+ARG URL
+ARG GA_MEASUREMENT_ID
 
 # Stage 1: Build environment with all dependencies
 FROM node:${NODE_VERSION}-alpine AS builder
@@ -50,6 +52,12 @@ COPY --chown=astro:astro public ./public/
 COPY --chown=astro:astro src ./src/
 COPY --chown=astro:astro types ./types/
 COPY --chown=astro:astro astro.config.mjs tsconfig.json ./
+
+# Variables needed for build only
+ARG URL
+ARG GA_MEASUREMENT_ID
+ENV URL=${URL}
+ENV GA_MEASUREMENT_ID=${GA_MEASUREMENT_ID}
 
 # Build application
 RUN pnpm run build


### PR DESCRIPTION
## Summary
Fixes Docker build issues by properly passing environment variables (URL and GA_MEASUREMENT_ID) to the build stage, ensuring they're available during the application build process.

## Changes

**Docker Configuration (`Dockerfile`)**
- **Build Arguments**: Added `ARG URL` and `ARG GA_MEASUREMENT_ID` declarations at the top level (lines 7-8)
- **Build Stage Environment**: Added build-time environment variable setup in the builder stage:
  - Re-declared build arguments (`ARG URL` and `ARG GA_MEASUREMENT_ID`) 
  - Set corresponding environment variables (`ENV URL=${URL}` and `ENV GA_MEASUREMENT_ID=${GA_MEASUREMENT_ID}`)
- **Timing**: Environment variables are set after copying source files but before running `pnpm run build`, ensuring they're available during the Astro build process

**Technical Context**
- Addresses Railway deployment issue where build-time environment variables weren't accessible during the Docker build stage
- These variables are likely used by Astro for site URL configuration and Google Analytics integration during static site generation
- Follows Docker best practices by using ARG for build-time values and ENV for runtime availability

---
🤖 Generated with gprc made by Walid + Claude